### PR TITLE
Fix arp requests in Liqo-Gateway

### DIFF
--- a/apis/net/v1alpha1/tunnel_endpoint_types.go
+++ b/apis/net/v1alpha1/tunnel_endpoint_types.go
@@ -66,6 +66,7 @@ type TunnelEndpointStatus struct {
 	TunnelIFaceName  string     `json:"tunnelIFaceName,omitempty"`
 	VethIFaceIndex   int        `json:"vethIFaceIndex,omitempty"`
 	VethIFaceName    string     `json:"vethIFaceName,omitempty"`
+	VethIP           string     `json:"vethIP,omitempty"`
 	GatewayIP        string     `json:"gatewayIP,omitempty"`
 	Connection       Connection `json:"connection,omitempty"`
 }

--- a/deployments/liqo/crds/net.liqo.io_tunnelendpoints.yaml
+++ b/deployments/liqo/crds/net.liqo.io_tunnelendpoints.yaml
@@ -137,6 +137,8 @@ spec:
                 type: integer
               vethIFaceName:
                 type: string
+              vethIP:
+                type: string
             type: object
         type: object
     served: true

--- a/internal/liqonet/route-operator/symmetricRoutingOperator.go
+++ b/internal/liqonet/route-operator/symmetricRoutingOperator.go
@@ -129,7 +129,7 @@ func (src *SymmetricRoutingController) addRoute(req ctrl.Request, p *corev1.Pod)
 	}
 	gwIP := utils.GetOverlayIP(nodeIP)
 	dstNet := strings.Join([]string{p.Status.PodIP, "32"}, "/")
-	added, err := routing.AddRoute(dstNet, gwIP, src.vxlanDev.Link.Attrs().Index, src.routingTableID)
+	added, err := routing.AddRoute(dstNet, gwIP, src.vxlanDev.Link.Attrs().Index, src.routingTableID, routing.DefaultFlags, routing.DefaultScope)
 	if err != nil {
 		return added, err
 	}

--- a/pkg/consts/liqonet.go
+++ b/pkg/consts/liqonet.go
@@ -58,13 +58,17 @@ const (
 	// HostVethName name of the veth device living in the host network namespace,
 	// on the node where liqo-gateway is running.
 	HostVethName = "liqo.host"
+	// HostVethIPAddr is used as next hop when configuring routes for traffic coming
+	// from the gateway namespace. A trick to prevent arp requests for the traffic going
+	// through the veth pair.
+	HostVethIPAddr = "169.254.100.2"
 	// GatewayVethName nome of the veth device living in the custom network namespace
 	// created by liqo-gateway.
 	GatewayVethName = "liqo.gateway"
-	// GatewayVethIPAddr ip address configured on gateway veth device. It is link local
-	// IP address. No traffic leaving the custom network namespace has as source IP this
-	// address.
-	GatewayVethIPAddr = "169.254.100.1/32"
+	// GatewayVethIPAddr is used as next hop when configuring routes for traffic coming
+	// from the host namespace. A trick to prevent arp requests for the traffic going
+	// through the veth pair.
+	GatewayVethIPAddr = "169.254.100.1"
 	// VxlanDeviceName name used for the vxlan devices created on each node by the instances
 	// of liqo-route.
 	VxlanDeviceName = "liqo.vxlan"

--- a/pkg/liqonet/netns/neigh.go
+++ b/pkg/liqonet/netns/neigh.go
@@ -1,0 +1,79 @@
+// Copyright 2019-2022 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package netns
+
+import (
+	"errors"
+	"net"
+	"syscall"
+
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
+	"k8s.io/klog/v2"
+)
+
+// AddNeigh adds a permanent neighbor entry for the given neighbor into the given device.
+// It returns an error if something goes wrong, and bool value set to true if it
+// added the entry, otherwise is set to false.
+func AddNeigh(addr net.IP, lladdr net.HardwareAddr, dev *net.Interface) (bool, error) {
+	klog.V(5).Infof("calling ip neigh add %s lladdr %s dev %s state permanent", addr, lladdr.String(), dev.Name)
+	// First we list all the neighbors
+	neighbors, err := netlink.NeighList(dev.Index, syscall.AF_INET)
+	if err != nil {
+		return false, err
+	}
+	// Check if the entry exists.
+	for i := range neighbors {
+		if neighbors[i].IP.Equal(addr) && neighbors[i].HardwareAddr.String() == lladdr.String() {
+			return false, nil
+		}
+	}
+	err = netlink.NeighSet(&netlink.Neigh{
+		LinkIndex:    dev.Index,
+		State:        netlink.NUD_PERMANENT,
+		Family:       syscall.AF_INET,
+		IP:           addr,
+		HardwareAddr: lladdr,
+	})
+	if err != nil {
+		return false, err
+	}
+	klog.V(5).Infof("neigh entry with mac {%s} and dst {%s} on device {%s} has been added",
+		lladdr.String(), addr, dev.Name)
+	return true, nil
+}
+
+// DelNeigh deletes a fdb entry for the given neighbor from the given device.
+// It return an error if something goes wrong, and bool value set to true if it
+// deleted the entry, if the entry does not exist the bool value is set to false.
+func DelNeigh(addr net.IP, lladdr net.HardwareAddr, dev *net.Interface) (bool, error) {
+	klog.V(5).Infof("calling ip neigh del %s lladdr %s dev %s", addr.String(), lladdr.String(), dev.Name)
+	err := netlink.NeighDel(&netlink.Neigh{
+		LinkIndex:    dev.Index,
+		State:        netlink.NUD_PERMANENT,
+		Family:       syscall.AF_INET,
+		IP:           addr,
+		HardwareAddr: lladdr,
+	})
+	if errors.Is(err, unix.ENOENT) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	klog.V(5).Infof("neigh entry with mac {%s} and dst {%s} on device {%s} has been removed",
+		lladdr.String(), addr.String(), dev.Name)
+	return true, nil
+}

--- a/pkg/liqonet/netns/netns.go
+++ b/pkg/liqonet/netns/netns.go
@@ -16,19 +16,12 @@ package netns
 
 import (
 	"runtime"
-	"time"
 
-	"github.com/containernetworking/plugins/pkg/ip"
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/gruntwork-io/gruntwork-cli/errors"
 	"github.com/vishvananda/netns"
 	"golang.org/x/sys/unix"
-	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
-
-	liqoneterrors "github.com/liqotech/liqo/pkg/liqonet/errors"
-	liqoutils "github.com/liqotech/liqo/pkg/liqonet/utils"
 )
 
 const (
@@ -79,46 +72,4 @@ func DeleteNetns(name string) error {
 		return err
 	}
 	return nil
-}
-
-// CreateVethPair it will create veth pair in originNetns and move one of them in dstNetns.
-// originNetns is the host netns and dstNetns is the gateway netns.
-// Error is returned if something goes wrong.
-func CreateVethPair(originVethName, dstVethName string, originNetns, dstNetns ns.NetNS, linkMTU int) error {
-	if originNetns == nil || dstNetns == nil {
-		return &liqoneterrors.WrongParameter{
-			Parameter: "originNetns and dstNetns",
-			Reason:    liqoneterrors.NotNil}
-	}
-	// Check if in originNetns, aka host netns, exists an interface named as originVethName.
-	// If it exists than we remove it.
-	err := originNetns.Do(func(currentNetns ns.NetNS) error {
-		return liqoutils.DeleteIFaceByName(originVethName)
-	})
-	if err != nil {
-		klog.Errorf("an error occurred while deleting interface {%s} in host network: %v", originVethName, err)
-		return err
-	}
-	var createVethPair = func(hostNS ns.NetNS) error {
-		_, _, err := ip.SetupVethWithName(originVethName, dstVethName, linkMTU, "", dstNetns)
-		if err != nil {
-			klog.Errorf("an error occurred while creating veth pair between host and gateway namespace: %v", err)
-			return err
-		}
-		return nil
-	}
-	// If we just delete the old network namespace it would require some time for the kernel to
-	// remove the veth device in the host network, so we retry in case of temporary conflicts.
-	retryiable := func(err error) bool {
-		return true
-	}
-	tryToCreateVeth := func() error {
-		return originNetns.Do(createVethPair)
-	}
-	return retry.OnError(wait.Backoff{
-		Steps:    5,
-		Duration: 100 * time.Millisecond,
-		Factor:   1.0,
-		Jitter:   0.1,
-	}, retryiable, tryToCreateVeth)
 }

--- a/pkg/liqonet/netns/netns_test.go
+++ b/pkg/liqonet/netns/netns_test.go
@@ -103,7 +103,7 @@ var _ = Describe("Netns", func() {
 			})
 
 			It("should add veth pair and return nil", func() {
-				err := CreateVethPair(hostVeth, gatewayVeth, originNetns, newNetns, 1500)
+				_, _, err := CreateVethPair(hostVeth, gatewayVeth, originNetns, newNetns, 1500)
 				Expect(err).ShouldNot(HaveOccurred())
 				// Get originVeth
 				or, err := netlink.LinkByName(hostVeth)
@@ -128,22 +128,22 @@ var _ = Describe("Netns", func() {
 			})
 
 			It("link exists in gateway netns, should return error", func() {
-				err := CreateVethPair(hostVeth, existingGatewayVeth, originNetns, newNetns, 1500)
+				_, _, err := CreateVethPair(hostVeth, existingGatewayVeth, originNetns, newNetns, 1500)
 				Expect(err).Should(HaveOccurred())
 			})
 
 			It("link exists in host netns, should remove it and create again", func() {
-				err := CreateVethPair(existingHostVeth, gatewayVeth, originNetns, newNetns, 1500)
+				_, _, err := CreateVethPair(existingHostVeth, gatewayVeth, originNetns, newNetns, 1500)
 				Expect(err).Should(BeNil())
 			})
 		})
 
 		Context("when dst network namespace does not exist", func() {
 			It("should return error", func() {
-				err := CreateVethPair(hostVeth, gatewayVeth, nil, nil, 1500)
+				_, _, err := CreateVethPair(hostVeth, gatewayVeth, nil, nil, 1500)
 				Expect(err).Should(Equal(&errors.WrongParameter{
 					Reason:    errors.NotNil,
-					Parameter: "originNetns and dstNetns",
+					Parameter: "hostNetns and gatewayNetns",
 				}))
 			})
 		})

--- a/pkg/liqonet/netns/veth.go
+++ b/pkg/liqonet/netns/veth.go
@@ -1,0 +1,141 @@
+// Copyright 2019-2022 The Liqo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package netns
+
+import (
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/containernetworking/plugins/pkg/ip"
+	"github.com/containernetworking/plugins/pkg/ns"
+	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/retry"
+	"k8s.io/klog/v2"
+
+	liqoconst "github.com/liqotech/liqo/pkg/consts"
+	liqoneterrors "github.com/liqotech/liqo/pkg/liqonet/errors"
+	liqorouting "github.com/liqotech/liqo/pkg/liqonet/routing"
+	liqoutils "github.com/liqotech/liqo/pkg/liqonet/utils"
+)
+
+// CreateVethPair it will create veth pair in hostNetns and move one of them in gatewayNetns.
+// hostNetns is the host netns and gatewayNetns is the gateway netns.
+// Error is returned if something goes wrong.
+func CreateVethPair(hostVethName, gatewayVethName string, hostNetns, gatewayNetns ns.NetNS,
+	linkMTU int) (hostVeth, gatewayVeth net.Interface, err error) {
+	if hostNetns == nil || gatewayNetns == nil {
+		return hostVeth, gatewayVeth, &liqoneterrors.WrongParameter{
+			Parameter: "hostNetns and gatewayNetns",
+			Reason:    liqoneterrors.NotNil}
+	}
+	// Check if in hostNetns, aka host netns, exists an interface named as hostVethName.
+	// If it exists than we remove it.
+	if err := liqoutils.DeleteIFaceByName(hostVethName); err != nil {
+		return hostVeth, gatewayVeth, fmt.Errorf("an error occurred while deleting interface {%s} in host network: %w",
+			hostVethName, err)
+	}
+
+	var createVethPair = func() error {
+		gatewayVeth, hostVeth, err = ip.SetupVethWithName(hostVethName, gatewayVethName, linkMTU, "", gatewayNetns)
+		if err != nil {
+			return fmt.Errorf("an error occurred while creating veth pair between host and gateway namespace: %w", err)
+		}
+		return nil
+	}
+	// If we just delete the old network namespace it would require some time for the kernel to
+	// remove the veth device in the host network, so we retry in case of temporary conflicts.
+	retryiable := func(err error) bool {
+		return true
+	}
+
+	return hostVeth, gatewayVeth, retry.OnError(wait.Backoff{
+		Steps:    5,
+		Duration: 100 * time.Millisecond,
+		Factor:   1.0,
+		Jitter:   0.1,
+	}, retryiable, createVethPair)
+}
+
+// ConfigureVeth configures the veth interface passed as argument. If the veth interface is the one
+// living the gateway netns then additional actions are carried out.
+func ConfigureVeth(veth *net.Interface, gatewayIP string, gatewayMAC net.HardwareAddr, netNS ns.NetNS) error {
+	var defaultCIDR = "0.0.0.0/0"
+
+	gwIP := net.ParseIP(gatewayIP)
+	if gwIP == nil {
+		return &liqoneterrors.ParseIPError{
+			IPToBeParsed: gatewayIP,
+		}
+	}
+
+	gwNet := gatewayIP + "/32"
+	klog.V(5).Infof("configuring veth {%s} with index {%d} in namespace with path {%s}",
+		veth.Name, veth.Index, netNS.Path())
+
+	configuration := func(netNamespace ns.NetNS) error {
+		// Disable arp on the veth link.
+		if err := netlink.LinkSetARPOff(&netlink.Veth{
+			LinkAttrs: netlink.LinkAttrs{
+				Index: veth.Index,
+			},
+		}); err != nil {
+			return fmt.Errorf("unable to disable arp for veth {%s} with index {%d} in namespace {%s}: %w",
+				veth.Name, veth.Index, netNS.Path(), err)
+		}
+		klog.V(5).Infof("arp correctly disabled for veth device {%s} with index {%d}", veth.Name, veth.Index)
+
+		// Add route for the gatewayIP used as next hop for the default route.
+		if _, err := liqorouting.AddRoute(gwNet, "", veth.Index, unix.RT_TABLE_MAIN, liqorouting.DefaultFlags, netlink.SCOPE_LINK); err != nil {
+			return fmt.Errorf("unable to configure route for ip {%s} on device {%s} with index {%d}: %w",
+				gatewayIP, veth.Name, veth.Index, err)
+		}
+		klog.V(5).Infof("route for ip {%s} correctly configured on device {%s} with index {%d}",
+			gatewayIP, veth.Name, veth.Index)
+
+		// Add static/permanent neighbor entry for the gateway IP address.
+		if _, err := AddNeigh(gwIP, gatewayMAC, veth); err != nil {
+			return fmt.Errorf("unable to add neighbor entry for ip {%s} and MAC {%s} on device {%s} with index {%d}",
+				gatewayIP, gatewayMAC.String(), veth.Name, veth.Index)
+		}
+		klog.V(5).Infof("neighbor entry for ip {%s} and MAC {%s} correctly configured on device {%s} with index {%d}",
+			gatewayIP, gatewayMAC.String(), veth.Name, veth.Index)
+
+		// The following configuration is done only for the veth pair living in the gateway network namespace.
+		if veth.Name == liqoconst.GatewayVethName {
+			// Add default route to use the veth interface.
+			if _, err := liqorouting.AddRoute(defaultCIDR, gatewayIP, veth.Index, unix.RT_TABLE_MAIN,
+				liqorouting.DefaultFlags, liqorouting.DefaultScope); err != nil {
+				return fmt.Errorf("unable to configure route for ip {%s} on device {%s} with index {%d}: %w",
+					defaultCIDR, veth.Name, veth.Index, err)
+			}
+			klog.V(5).Infof("route for ip {%s} correctly configured on device {%s} with index {%d}",
+				defaultCIDR, veth.Name, veth.Index)
+
+			// Enable ip forwarding in the gateway namespace.
+			if err := liqorouting.EnableIPForwarding(); err != nil {
+				return fmt.Errorf("unable to enable ip forwarding in namespace {%s}: %w", netNS.Path(), err)
+			}
+			klog.V(5).Infof("ipv4 forwarding in namespace {%s} with path {%s} correctly enabled",
+				liqoconst.GatewayNetnsName, netNS.Path())
+		}
+
+		return nil
+	}
+
+	return netNS.Do(configuration)
+}

--- a/pkg/liqonet/routing/common_test.go
+++ b/pkg/liqonet/routing/common_test.go
@@ -73,13 +73,13 @@ var _ = Describe("Common", func() {
 	Describe("adding new route", func() {
 		Context("when input parameters are not in the correct format", func() {
 			It("should return error on wrong destination net", func() {
-				added, err := AddRoute(dstNetWrong, gwIPCorrect, dummylink1.Attrs().Index, routingTableID)
+				added, err := AddRoute(dstNetWrong, gwIPCorrect, dummylink1.Attrs().Index, routingTableID, DefaultFlags, DefaultScope)
 				Expect(added).Should(Equal(false))
 				Expect(err).Should(Equal(&net.ParseError{Type: "CIDR address", Text: dstNetWrong}))
 			})
 
 			It("should return error on wrong gateway IP address", func() {
-				added, err := AddRoute(dstNetCorrect, gwIPWrong, dummylink1.Attrs().Index, routingTableID)
+				added, err := AddRoute(dstNetCorrect, gwIPWrong, dummylink1.Attrs().Index, routingTableID, DefaultFlags, DefaultScope)
 				Expect(added).Should(Equal(false))
 				Expect(err).Should(Equal(&errors.ParseIPError{IPToBeParsed: gwIPWrong}))
 			})
@@ -87,7 +87,7 @@ var _ = Describe("Common", func() {
 
 		Context("when an error occurred while adding a route", func() {
 			It("should return an error on non existing link", func() {
-				added, err := AddRoute(dstNetCorrect, gwIPWrong, 0, routingTableID)
+				added, err := AddRoute(dstNetCorrect, gwIPWrong, 0, routingTableID, DefaultFlags, DefaultScope)
 				Expect(added).Should(Equal(false))
 				Expect(err).To(HaveOccurred())
 			})
@@ -95,7 +95,7 @@ var _ = Describe("Common", func() {
 
 		Context("when route does not exist and we want to add it", func() {
 			It("no gatewayIP, should return true and nil", func() {
-				added, err := AddRoute(dstNetCorrect, "", dummylink1.Attrs().Index, routingTableID)
+				added, err := AddRoute(dstNetCorrect, "", dummylink1.Attrs().Index, routingTableID, DefaultFlags, DefaultScope)
 				Expect(added).Should(Equal(true))
 				Expect(err).NotTo(HaveOccurred())
 				// Get the route and check it has the right parameters
@@ -105,7 +105,7 @@ var _ = Describe("Common", func() {
 			})
 
 			It("with gatewayIP, should return true and nil", func() {
-				added, err := AddRoute(dstNetCorrect, gwIPCorrect, dummylink1.Attrs().Index, routingTableID)
+				added, err := AddRoute(dstNetCorrect, gwIPCorrect, dummylink1.Attrs().Index, routingTableID, DefaultFlags, DefaultScope)
 				Expect(added).Should(Equal(true))
 				Expect(err).NotTo(HaveOccurred())
 				// Get the route and check it has the right parameters
@@ -126,19 +126,22 @@ var _ = Describe("Common", func() {
 
 			It("should return false and nil", func() {
 				// Add existing route with GW.
-				added, err := AddRoute(existingRoutesCM[0].Dst.String(), existingRoutesCM[0].Gw.String(), existingRoutesCM[0].LinkIndex, existingRoutesCM[0].Table)
+				added, err := AddRoute(existingRoutesCM[0].Dst.String(), existingRoutesCM[0].Gw.String(), existingRoutesCM[0].LinkIndex,
+					existingRoutesCM[0].Table, DefaultFlags, DefaultScope)
 				Expect(added).Should(Equal(false))
 				Expect(err).NotTo(HaveOccurred())
 
 				// Add existing route without GW.
-				added, err = AddRoute(existingRoutesCM[1].Dst.String(), "", existingRoutesCM[1].LinkIndex, existingRoutesCM[1].Table)
+				added, err = AddRoute(existingRoutesCM[1].Dst.String(), "", existingRoutesCM[1].LinkIndex, existingRoutesCM[1].Table,
+					DefaultFlags, DefaultScope)
 				Expect(added).Should(Equal(false))
 				Expect(err).NotTo(HaveOccurred())
 			})
 
 			It("update gateway of existing route: should return true and nil", func() {
 				// Update route with GW
-				added, err := AddRoute(existingRoutesCM[0].Dst.String(), "", existingRoutesCM[0].LinkIndex, existingRoutesCM[0].Table)
+				added, err := AddRoute(existingRoutesCM[0].Dst.String(), "", existingRoutesCM[0].LinkIndex, existingRoutesCM[0].Table,
+					DefaultFlags, DefaultScope)
 				Expect(added).Should(Equal(true))
 				Expect(err).NotTo(HaveOccurred())
 				// Get the route and check it has the right parameters
@@ -147,7 +150,8 @@ var _ = Describe("Common", func() {
 				Expect(routes[0].Gw).Should(BeNil())
 
 				// Update route without GW
-				added, err = AddRoute(existingRoutesCM[1].Dst.String(), gwIPCorrect, existingRoutesCM[1].LinkIndex, existingRoutesCM[1].Table)
+				added, err = AddRoute(existingRoutesCM[1].Dst.String(), gwIPCorrect, existingRoutesCM[1].LinkIndex, existingRoutesCM[1].Table,
+					DefaultFlags, DefaultScope)
 				Expect(added).Should(Equal(true))
 				Expect(err).NotTo(HaveOccurred())
 				// Get the route and check it has the right parameters
@@ -158,7 +162,8 @@ var _ = Describe("Common", func() {
 
 			It("update link index of existing route: should return true and nil", func() {
 				// Update route with GW
-				added, err := AddRoute(existingRoutesCM[0].Dst.String(), existingRoutesCM[0].Gw.String(), dummyLink2.Attrs().Index, existingRoutesCM[0].Table)
+				added, err := AddRoute(existingRoutesCM[0].Dst.String(), existingRoutesCM[0].Gw.String(), dummyLink2.Attrs().Index,
+					existingRoutesCM[0].Table, DefaultFlags, DefaultScope)
 				Expect(added).Should(Equal(true))
 				Expect(err).NotTo(HaveOccurred())
 				// Get the route and check it has the right parameters
@@ -167,7 +172,8 @@ var _ = Describe("Common", func() {
 				Expect(routes[0].LinkIndex).Should(BeNumerically("==", dummyLink2.Attrs().Index))
 
 				// Update route without GW
-				added, err = AddRoute(existingRoutesCM[1].Dst.String(), gwIPCorrect, dummyLink2.Attrs().Index, existingRoutesCM[1].Table)
+				added, err = AddRoute(existingRoutesCM[1].Dst.String(), gwIPCorrect, dummyLink2.Attrs().Index,
+					existingRoutesCM[1].Table, DefaultFlags, DefaultScope)
 				Expect(added).Should(Equal(true))
 				Expect(err).NotTo(HaveOccurred())
 				// Get the route and check it has the right parameters
@@ -524,26 +530,6 @@ var _ = Describe("Common", func() {
 				txt, err := os.ReadFile("/proc/sys/net/ipv4/ip_forward")
 				Expect(err).ShouldNot(HaveOccurred())
 				Expect(txt[0]).Should(Equal(enabled))
-			})
-		})
-	})
-
-	Describe("enabling proxy arp", func() {
-		Context("enable proxy arp for an existing interface", func() {
-			It("should return nil", func() {
-				var enabled byte = '1'
-				err := EnableProxyArp(dummylink1.Attrs().Name)
-				Expect(err).ShouldNot(HaveOccurred())
-				txt, err := os.ReadFile("/proc/sys/net/ipv4/conf/" + dummylink1.Attrs().Name + "/proxy_arp")
-				Expect(err).ShouldNot(HaveOccurred())
-				Expect(txt[0]).Should(Equal(enabled))
-			})
-		})
-
-		Context("enable proxy arp for non existing interface", func() {
-			It("should return error", func() {
-				err := EnableProxyArp("doesNotExist")
-				Expect(err).Should(HaveOccurred())
 			})
 		})
 	})

--- a/pkg/liqonet/routing/directRouting.go
+++ b/pkg/liqonet/routing/directRouting.go
@@ -81,13 +81,13 @@ func (drm *DirectRoutingManager) EnsureRoutesPerCluster(tep *netv1alpha1.TunnelE
 	// Add routes for the given cluster.
 	klog.Infof("%s -> adding route for destination {%s} with gateway {%s} in routing table with ID {%d}",
 		clusterID, dstPodCIDR, gatewayIP, drm.routingTableID)
-	routePodCIDRAdd, err = AddRoute(dstPodCIDR, gatewayIP, iFaceIndex, drm.routingTableID)
+	routePodCIDRAdd, err = AddRoute(dstPodCIDR, gatewayIP, iFaceIndex, drm.routingTableID, DefaultFlags, DefaultScope)
 	if err != nil {
 		return routePodCIDRAdd, err
 	}
 	klog.Infof("%s -> adding route for destination {%s} with gateway {%s} in routing table with ID {%d}",
 		clusterID, dstExternalCIDR, gatewayIP, drm.routingTableID)
-	routeExternalCIDRAdd, err = AddRoute(dstExternalCIDR, gatewayIP, iFaceIndex, drm.routingTableID)
+	routeExternalCIDRAdd, err = AddRoute(dstExternalCIDR, gatewayIP, iFaceIndex, drm.routingTableID, DefaultFlags, DefaultScope)
 	if err != nil {
 		return routeExternalCIDRAdd, err
 	}

--- a/pkg/liqonet/routing/gatewayRouting.go
+++ b/pkg/liqonet/routing/gatewayRouting.go
@@ -64,11 +64,11 @@ func (grm *GatewayRoutingManager) EnsureRoutesPerCluster(tep *netv1alpha1.Tunnel
 	_, dstPodCIDRNet := utils.GetPodCIDRS(tep)
 	_, dstExternalCIDRNet := utils.GetExternalCIDRS(tep)
 	// Add routes for the given cluster.
-	routePodCIDRAdd, err = AddRoute(dstPodCIDRNet, "", grm.tunnelDevice.Attrs().Index, grm.routingTableID)
+	routePodCIDRAdd, err = AddRoute(dstPodCIDRNet, "", grm.tunnelDevice.Attrs().Index, grm.routingTableID, DefaultFlags, DefaultScope)
 	if err != nil {
 		return routePodCIDRAdd, err
 	}
-	routeExternalCIDRAdd, err = AddRoute(dstExternalCIDRNet, "", grm.tunnelDevice.Attrs().Index, grm.routingTableID)
+	routeExternalCIDRAdd, err = AddRoute(dstExternalCIDRNet, "", grm.tunnelDevice.Attrs().Index, grm.routingTableID, DefaultFlags, DefaultScope)
 	if err != nil {
 		return routeExternalCIDRAdd, err
 	}

--- a/pkg/liqonet/routing/vxlanRouting_test.go
+++ b/pkg/liqonet/routing/vxlanRouting_test.go
@@ -176,31 +176,22 @@ var _ = Describe("VxlanRouting", func() {
 			It("route configuration fails while adding policy routing rule for PodCIDR", func() {
 				tepVRM.Spec.RemoteNATPodCIDR = ""
 				added, err := vrm.EnsureRoutesPerCluster(&tepVRM)
-				Expect(err).Should(Equal(&liqoerrors.WrongParameter{
-					Parameter: "fromSubnet and toSubnet",
-					Reason:    liqoerrors.AtLeastOneValid,
-				}))
 				Expect(added).Should(BeFalse())
-				Expect(err).NotTo(BeNil())
+				Expect(err).Should(HaveOccurred())
 			})
 
 			It("route configuration fails while adding policy routing rule for ExternalCIDR", func() {
 				tepVRM.Spec.RemoteNATExternalCIDR = ""
 				added, err := vrm.EnsureRoutesPerCluster(&tepVRM)
-				Expect(err).Should(Equal(&liqoerrors.WrongParameter{
-					Parameter: "fromSubnet and toSubnet",
-					Reason:    liqoerrors.AtLeastOneValid,
-				}))
 				Expect(added).Should(BeFalse())
-				Expect(err).NotTo(BeNil())
+				Expect(err).Should(HaveOccurred())
 			})
 
 			It("route configuration fails while adding route", func() {
 				tepVRM.Status.GatewayIP = ipAddress1NoSubnet
 				added, err := vrm.EnsureRoutesPerCluster(&tepVRM)
-				Expect(err).Should(Equal(unix.ENODEV))
 				Expect(added).Should(BeFalse())
-				Expect(err).NotTo(BeNil())
+				Expect(err).Should(HaveOccurred())
 			})
 		})
 	})
@@ -263,22 +254,14 @@ var _ = Describe("VxlanRouting", func() {
 			It("fails to remove route configuration while removing policy routing rule for PodCIDR", func() {
 				tepVRM.Spec.RemoteNATPodCIDR = ""
 				added, err := vrm.RemoveRoutesPerCluster(&tepVRM)
-				Expect(err).Should(Equal(&liqoerrors.WrongParameter{
-					Parameter: "fromSubnet and toSubnet",
-					Reason:    liqoerrors.AtLeastOneValid,
-				}))
 				Expect(added).Should(BeFalse())
-				Expect(err).NotTo(BeNil())
+				Expect(err).Should(HaveOccurred())
 			})
 			It("fails to remove route configuration while removing policy routing rule for ExternalCIDR", func() {
 				tepVRM.Spec.RemoteNATExternalCIDR = ""
 				added, err := vrm.RemoveRoutesPerCluster(&tepVRM)
-				Expect(err).Should(Equal(&liqoerrors.WrongParameter{
-					Parameter: "fromSubnet and toSubnet",
-					Reason:    liqoerrors.AtLeastOneValid,
-				}))
 				Expect(added).Should(BeFalse())
-				Expect(err).NotTo(BeNil())
+				Expect(err).Should(HaveOccurred())
 			})
 		})
 
@@ -309,8 +292,9 @@ var _ = Describe("VxlanRouting", func() {
 
 			It("route configuration should be correctly removed from veth pair", func() {
 				tepVRM.Spec.RemoteNATPodCIDR = existingRoutesVRM[1].Dst.String()
-				tepVRM.Spec.RemoteNATPodCIDR = existingRoutesVRM[0].Dst.String()
+				tepVRM.Spec.RemoteNATExternalCIDR = existingRoutesVRM[0].Dst.String()
 				tepVRM.Status.GatewayIP = ipAddress1NoSubnet
+				tepVRM.Status.VethIP = existingRoutesVRM[1].Gw.String()
 				tepVRM.Status.VethIFaceIndex = overlayDevice.Link.Index
 				added, err := vrm.RemoveRoutesPerCluster(&tepVRM)
 				Expect(err).ShouldNot(HaveOccurred())

--- a/pkg/liqonet/tunnel/wireguard/driver.go
+++ b/pkg/liqonet/tunnel/wireguard/driver.go
@@ -487,6 +487,7 @@ func (w *Wireguard) setKeys(c k8s.Interface, namespace string) error {
 
 // SetNewClient set a new client used to interact with the wireguard device.
 func (w *Wireguard) SetNewClient() error {
+
 	c, err := wgctrl.New()
 	if err != nil {
 		if os.IsNotExist(err) {


### PR DESCRIPTION
# Description

The fix provides a way to route traffic between network namespace without the need of `ARP` requests hence decreasing the latency for new inter-cluster connections.


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also note any relevant details for your test configuration.

- [x] Existing Unit and E2E tests
